### PR TITLE
fixed further ifdef references for RoleAnnotations

### DIFF
--- a/src/Data/HyperLogLog/Config.hs
+++ b/src/Data/HyperLogLog/Config.hs
@@ -18,7 +18,7 @@
 {-# OPTIONS_GHC -fno-float-in #-}
 {-# OPTIONS_GHC -fno-warn-unused-binds #-}
 
-#if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ >= 706
+#if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ >= 707
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE PolyKinds #-}
 #define USE_TYPE_LITS 1

--- a/src/Data/HyperLogLog/Type.hs
+++ b/src/Data/HyperLogLog/Type.hs
@@ -98,7 +98,7 @@ import           GHC.Int
 newtype HyperLogLog p = HyperLogLog { runHyperLogLog :: V.Vector Rank }
     deriving (Eq, Show, Generic)
 
-#if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ >= 706
+#if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ >= 707
 type role HyperLogLog nominal
 #endif
 


### PR DESCRIPTION
There were two more spots where the GLASGOW_HASKELL number needed bumping to 707.  The PolyKinds ifdef still references 706 but since it compiles I left it along.  I didn't bump the package version just in case you can squeeze this in before it ships. 
