### PR TITLE
Compatibility update for lens-4.4

### DIFF
--- a/hyperloglog.cabal
+++ b/hyperloglog.cabal
@@ -61,7 +61,7 @@ library
     generic-deriving          >= 1.4      && < 1.7,
     hashable                  >= 1.1.2.3  && < 1.3,
     hashable-extras           >= 0.1      && < 1,
-    lens                      >= 4        && < 4.4,
+    lens                      >= 4        && < 4.5,
     reflection                >= 1.3      && < 2,
     semigroupoids             >= 4        && < 5,
     semigroups                >= 0.8.4    && < 1,

--- a/src/Data/HyperLogLog/Config.hs
+++ b/src/Data/HyperLogLog/Config.hs
@@ -8,7 +8,6 @@
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE UndecidableInstances #-}
-{-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE FunctionalDependencies #-}
 {-# LANGUAGE FlexibleInstances #-}
@@ -48,7 +47,6 @@ module Data.HyperLogLog.Config
     Config
   , HasConfig(..)
   , hll
-  , numBits, numBuckets, smallRange, interRange, rawFact, alpha, bucketMask
   -- * ReifiesConfig
   , ReifiesConfig(..)
   , reifyConfig
@@ -91,12 +89,28 @@ data Config = Config
   } deriving (Eq, Show, Generic)
 
 class HasConfig t where
-  config :: Getter t Config
+  config     :: Getter t Config
 
-makeLensesWith ?? ''Config $ classyRules
-  & generateSignatures .~ False
-  & createClass        .~ False
-  & createInstance     .~ False
+  numBits    :: Getter t Int
+  numBits     = config . to _numBits
+
+  numBuckets :: Getter t Int
+  numBuckets  = config . to _numBuckets
+
+  smallRange :: Getter t Double
+  smallRange  = config . to _smallRange
+
+  interRange :: Getter t Double
+  interRange  = config . to _interRange
+
+  rawFact    :: Getter t Double
+  rawFact     = config . to _rawFact
+
+  alpha      :: Getter t Double
+  alpha       = config . to _alpha
+
+  bucketMask :: Getter t Word32
+  bucketMask  = config . to _bucketMask
 
 instance HasConfig Config where
   config = id

--- a/src/Data/HyperLogLog/Type.hs
+++ b/src/Data/HyperLogLog/Type.hs
@@ -9,7 +9,6 @@
 {-# LANGUAGE RankNTypes                #-}
 {-# LANGUAGE RecordWildCards           #-}
 {-# LANGUAGE ScopedTypeVariables       #-}
-{-# LANGUAGE TemplateHaskell           #-}
 {-# LANGUAGE TypeFamilies              #-}
 {-# LANGUAGE UndecidableInstances      #-}
 {-# OPTIONS_GHC -fno-cse #-}
@@ -104,7 +103,11 @@ type role HyperLogLog nominal
 
 instance Serialize (HyperLogLog p)
 
-makeClassy ''HyperLogLog
+class HasHyperLogLog a p | a -> p where
+  hyperLogLog :: Lens' a (HyperLogLog p)
+
+instance HasHyperLogLog (HyperLogLog p) p where
+  hyperLogLog = id
 
 _HyperLogLog :: Iso' (HyperLogLog p) (V.Vector Rank)
 _HyperLogLog = iso runHyperLogLog HyperLogLog


### PR DESCRIPTION
Changes to the way makeClassy worked make hyperloglog's old
implementation incompatible with makeClassy in 4.4. While
changes to this are in the works, they won't be ready until 4.5.
Manually implementing the bits that were previously implemented
with Template Haskell will allow users to proceed using lens-4.4
