### PR TITLE
Export config coercion from Data.HyperLogLog

### DIFF
--- a/src/Data/HyperLogLog.hs
+++ b/src/Data/HyperLogLog.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 --------------------------------------------------------------------
 -- |
 -- Copyright :  (c) Edward Kmett 2013-2015
@@ -19,6 +20,9 @@ module Data.HyperLogLog
   , insert
   , insertHash
   , cast
+#if __GLASGOW_HASKELL__ >= 708
+  , coerceConfig
+#endif
   -- * Config
   , Config
   , hll


### PR DESCRIPTION
Those who've opened up Data.HyperLogLog.Type already have full
access to the newtype constructor, and are presumably in
hyper-vigilant mode.