### PR TITLE
Version bump of packages for GHC 8.0

### DIFF
--- a/hyperloglog.cabal
+++ b/hyperloglog.cabal
@@ -1,6 +1,6 @@
 name:          hyperloglog
 category:      Numeric
-version:       0.4.0.4
+version:       0.4.0.5
 license:       BSD3
 cabal-version: >= 1.8
 license-file:  LICENSE
@@ -50,12 +50,12 @@ library
   build-depends:
     approximate               >= 0.2.1    && < 1,
     base                      >= 4.3      && < 5,
-    binary                    >= 0.5      && < 0.8,
+    binary                    >= 0.5      && < 0.9,
     bits                      >= 0.2      && < 1,
     bytes                     >= 0.7      && < 1,
     cereal                    >= 0.3.5    && < 0.6,
     cereal-vector             >= 0.2      && < 0.3,
-    comonad                   >= 4        && < 5,
+    comonad                   >= 4        && < 6,
     deepseq                   >= 1.3      && < 1.5,
     distributive              >= 0.3      && < 1,
     hashable                  >= 1.1.2.3  && < 1.3,


### PR DESCRIPTION
In a chase of SubHask and Herbie plugin to Stackage and GHC 8.0, the version bumps were made in this package to be compatible with the latest nightly Stackage.

Please review the changes and if they are ok, release the package to stackage.