### PR TITLE
Internalize the `siphash` library

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.13.20211114
+# version: 0.14.3
 #
-# REGENDATA ("0.13.20211114",["github","cabal.project"])
+# REGENDATA ("0.14.3",["github","cabal.project"])
 #
 name: Haskell-CI
 on:
@@ -28,15 +28,15 @@ jobs:
     strategy:
       matrix:
         include:
-          - compiler: ghc-9.2.1
+          - compiler: ghc-9.2.2
             compilerKind: ghc
-            compilerVersion: 9.2.1
+            compilerVersion: 9.2.2
             setup-method: ghcup
-            allow-failure: true
-          - compiler: ghc-9.0.1
+            allow-failure: false
+          - compiler: ghc-9.0.2
             compilerKind: ghc
-            compilerVersion: 9.0.1
-            setup-method: hvr-ppa
+            compilerVersion: 9.0.2
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.10.7
             compilerKind: ghc
@@ -76,7 +76,7 @@ jobs:
           apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5
           if [ "${{ matrix.setup-method }}" = ghcup ]; then
             mkdir -p "$HOME/.ghcup/bin"
-            curl -sL https://downloads.haskell.org/ghcup/0.1.17.3/x86_64-linux-ghcup-0.1.17.3 > "$HOME/.ghcup/bin/ghcup"
+            curl -sL https://downloads.haskell.org/ghcup/0.1.17.5/x86_64-linux-ghcup-0.1.17.5 > "$HOME/.ghcup/bin/ghcup"
             chmod a+x "$HOME/.ghcup/bin/ghcup"
             "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER"
             "$HOME/.ghcup/bin/ghcup" install cabal 3.6.2.0
@@ -85,7 +85,7 @@ jobs:
             apt-get update
             apt-get install -y "$HCNAME"
             mkdir -p "$HOME/.ghcup/bin"
-            curl -sL https://downloads.haskell.org/ghcup/0.1.17.3/x86_64-linux-ghcup-0.1.17.3 > "$HOME/.ghcup/bin/ghcup"
+            curl -sL https://downloads.haskell.org/ghcup/0.1.17.5/x86_64-linux-ghcup-0.1.17.5 > "$HOME/.ghcup/bin/ghcup"
             chmod a+x "$HOME/.ghcup/bin/ghcup"
             "$HOME/.ghcup/bin/ghcup" install cabal 3.6.2.0
           fi
@@ -118,7 +118,7 @@ jobs:
           echo "HCNUMVER=$HCNUMVER" >> "$GITHUB_ENV"
           echo "ARG_TESTS=--enable-tests" >> "$GITHUB_ENV"
           echo "ARG_BENCH=--enable-benchmarks" >> "$GITHUB_ENV"
-          if [ $((HCNUMVER >= 90200)) -ne 0 ] ; then echo "HEADHACKAGE=true" >> "$GITHUB_ENV" ; else echo "HEADHACKAGE=false" >> "$GITHUB_ENV" ; fi
+          echo "HEADHACKAGE=false" >> "$GITHUB_ENV"
           echo "ARG_COMPILER=--$HCKIND --with-compiler=$HC" >> "$GITHUB_ENV"
           echo "GHCJSARITH=0" >> "$GITHUB_ENV"
         env:
@@ -147,17 +147,6 @@ jobs:
           repository hackage.haskell.org
             url: http://hackage.haskell.org/
           EOF
-          if $HEADHACKAGE; then
-          cat >> $CABAL_CONFIG <<EOF
-          repository head.hackage.ghc.haskell.org
-             url: https://ghc.gitlab.haskell.org/head.hackage/
-             secure: True
-             root-keys: 7541f32a4ccca4f97aea3b22f5e593ba2c0267546016b992dfadcd2fe944e55d
-                        26021a13b401500c8eb2761ca95c61f2d625bfef951b939a8124ed12ecf07329
-                        f76d08be13e9a61a377a85e2fb63f4c5435d40f8feb3e12eb05905edb8cdea89
-             key-threshold: 3
-          EOF
-          fi
           cat >> $CABAL_CONFIG <<EOF
           program-default-options
             ghc-options: $GHCJOBS +RTS -M3G -RTS
@@ -218,9 +207,6 @@ jobs:
           if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods" >> cabal.project ; fi
           cat >> cabal.project <<EOF
           EOF
-          if $HEADHACKAGE; then
-          echo "allow-newer: $($HCPKG list --simple-output | sed -E 's/([a-zA-Z-]+)-[0-9.]+/*:\1,/g')" >> cabal.project
-          fi
           $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: $_ installed\n" unless /^(hyperloglog)$/; }' >> cabal.project.local
           cat cabal.project
           cat cabal.project.local

--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,3 +1,9 @@
+next [????.??.??]
+-----------------
+* Remove the `siphash` dependency. Because `siphash` no longer builds on
+  GHC 9.2+, we instead bundle the code alongside `hyperloglog`. This allows
+  `hyperloglog` to build with 9.2.
+
 0.4.5 [2021.11.16]
 ------------------
 * Drop support for pre-8.0 versions of GHC.

--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -4,4 +4,3 @@ unconstrained:          False
 -- irc-channels:           irc.freenode.org#haskell-lens
 irc-if-in-origin-repo:  True
 docspec:                True
-head-hackage:           >=9.2

--- a/hyperloglog.cabal
+++ b/hyperloglog.cabal
@@ -62,7 +62,6 @@ library
     reflection                >= 1.3      && < 3,
     semigroupoids             >= 4        && < 6,
     semigroups                >= 0.8.4    && < 1,
-    siphash                   >= 1.0.3    && < 2,
     tagged                    >= 0.4.5    && < 1,
     vector                    >= 0.9      && < 0.13
 
@@ -75,6 +74,13 @@ library
     Data.HyperLogLog
     Data.HyperLogLog.Config
     Data.HyperLogLog.Type
+
+  other-modules:
+    Crypto.MAC.SipHash
+  -- Only needed for Crypto.MAC.SipHash
+  build-depends:
+    bytestring  >= 0.9 && < 0.11,
+    cpu         >= 0.1 && < 0.2
 
   ghc-options: -Wall -Wtabs -O2
   hs-source-dirs: src

--- a/hyperloglog.cabal
+++ b/hyperloglog.cabal
@@ -17,8 +17,8 @@ tested-with:   GHC == 8.0.2
              , GHC == 8.6.5
              , GHC == 8.8.4
              , GHC == 8.10.7
-             , GHC == 9.0.1
-             , GHC == 9.2.1
+             , GHC == 9.0.2
+             , GHC == 9.2.2
 synopsis:      An approximate streaming (constant space) unique object counter
 description:
   This package provides an approximate streaming (constant space) unique object counter.

--- a/hyperloglog.cabal
+++ b/hyperloglog.cabal
@@ -79,7 +79,7 @@ library
     Crypto.MAC.SipHash
   -- Only needed for Crypto.MAC.SipHash
   build-depends:
-    bytestring  >= 0.9 && < 0.11,
+    bytestring  >= 0.9 && < 0.12,
     cpu         >= 0.1 && < 0.2
 
   ghc-options: -Wall -Wtabs -O2

--- a/src/Crypto/MAC/SipHash.hs
+++ b/src/Crypto/MAC/SipHash.hs
@@ -25,9 +25,7 @@ module Crypto.MAC.SipHash
 
 import Data.Word
 import Data.Bits
-import Data.ByteString (ByteString)
 import Data.ByteString.Internal
-import qualified Data.ByteString as B
 import Control.Monad
 
 import Foreign.ForeignPtr
@@ -112,6 +110,7 @@ hashWith c d key (PS ps s fl) = unsafeDupablePerformIO $ withForeignPtr ps (\ptr
                                     .|. (to64 v2 `unsafeShiftL` 16)
                                     .|. (to64 v1 `unsafeShiftL` 8)
                                     .|. to64 v0)
+                    _ -> error "siphash: internal error: cannot happen"
 
         {-# INLINE to64 #-}
         to64 :: Word8 -> Word64

--- a/src/Crypto/MAC/SipHash.hs
+++ b/src/Crypto/MAC/SipHash.hs
@@ -1,0 +1,166 @@
+-- |
+-- Module      : Crypto.MAC.SipHash
+-- License     : BSD-style
+-- Maintainer  : Vincent Hanquez <vincent@snarc.org>
+-- Stability   : experimental
+-- Portability : good
+--
+-- provide the SipHash algorithm.
+-- reference: <http://131002.net/siphash/siphash.pdf>
+--
+-- This is a copy of the code from the @siphash@ library, which is licensed
+-- under the 3-Clause BSD License. Unfortunately, @siphash@ no longer compiles
+-- on GHC 9.2 or later, and since @siphash@ is deprecated, it is unlikely that
+-- it will receive future updates. For the time being, we have opted to
+-- internalize the code in the @hyperloglog@ library, as it is relatively
+-- self-contained. In the future, we may want to consider offering this code as
+-- a standalone library.
+{-# LANGUAGE BangPatterns #-}
+module Crypto.MAC.SipHash
+    ( SipKey(..)
+    , SipHash(..)
+    , hash
+    , hashWith
+    ) where
+
+import Data.Word
+import Data.Bits
+import Data.ByteString (ByteString)
+import Data.ByteString.Internal
+import qualified Data.ByteString as B
+import Control.Monad
+
+import Foreign.ForeignPtr
+import Foreign.Ptr
+import Foreign.Storable
+import System.Endian (fromLE64)
+
+-- | SigHash Key
+data SipKey = SipKey {-# UNPACK #-} !Word64 {-# UNPACK #-} !Word64
+
+-- | Siphash tag value
+newtype SipHash = SipHash Word64
+    deriving (Show,Eq)
+
+data InternalState = InternalState {-# UNPACK #-} !Word64 {-# UNPACK #-} !Word64 {-# UNPACK #-} !Word64 {-# UNPACK #-} !Word64
+
+-- | produce a siphash with a key and a bytestring.
+hash :: SipKey -> ByteString -> SipHash
+hash = hashWith 2 4
+
+-- | same as 'hash', except also specifies the number of sipround iterations for compression and digest.
+hashWith :: Int -> Int -> SipKey -> ByteString -> SipHash
+hashWith c d key (PS ps s fl) = inlinePerformIO $ withForeignPtr ps (\ptr -> runHash (initSip key) (ptr `plusPtr` s) fl)
+  where runHash !st !ptr l
+            | l > 7     = fromLE64 `fmap` peek (castPtr ptr) >>= \v -> runHash (process st v) (ptr `plusPtr` 8) (l-8)
+            | otherwise = do
+                let !lengthBlock = (fromIntegral fl `mod` 256) `unsafeShiftL` 56
+                (finish . process st) `fmap` case l of
+                    0 -> do return lengthBlock
+                    1 -> do v0 <- peekByteOff ptr 0
+                            return (lengthBlock .|. to64 v0)
+                    2 -> do (v0,v1) <- liftM2 (,) (peekByteOff ptr 0) (peekByteOff ptr 1)
+                            return (lengthBlock
+                                    .|. (to64 v1 `unsafeShiftL` 8)
+                                    .|. to64 v0)
+                    3 -> do (v0,v1,v2) <- liftM3 (,,) (peekByteOff ptr 0) (peekByteOff ptr 1) (peekByteOff ptr 2)
+                            return (    lengthBlock
+                                    .|. (to64 v2 `unsafeShiftL` 16)
+                                    .|. (to64 v1 `unsafeShiftL` 8)
+                                    .|. to64 v0)
+                    4 -> do (v0,v1,v2,v3) <- liftM4 (,,,) (peekByteOff ptr 0) (peekByteOff ptr 1) (peekByteOff ptr 2)
+                                                          (peekByteOff ptr 3)
+                            return (    lengthBlock
+                                    .|. (to64 v3 `unsafeShiftL` 24)
+                                    .|. (to64 v2 `unsafeShiftL` 16)
+                                    .|. (to64 v1 `unsafeShiftL` 8)
+                                    .|. to64 v0)
+                    5 -> do (v0,v1,v2,v3,v4) <- liftM5 (,,,,) (peekByteOff ptr 0) (peekByteOff ptr 1) (peekByteOff ptr 2)
+                                                              (peekByteOff ptr 3) (peekByteOff ptr 4)
+                            return (    lengthBlock
+                                    .|. (to64 v4 `unsafeShiftL` 32)
+                                    .|. (to64 v3 `unsafeShiftL` 24)
+                                    .|. (to64 v2 `unsafeShiftL` 16)
+                                    .|. (to64 v1 `unsafeShiftL` 8)
+                                    .|. to64 v0)
+                    6 -> do v0 <- peekByteOff ptr 0
+                            v1 <- peekByteOff ptr 1
+                            v2 <- peekByteOff ptr 2
+                            v3 <- peekByteOff ptr 3
+                            v4 <- peekByteOff ptr 4
+                            v5 <- peekByteOff ptr 5
+                            return (    lengthBlock
+                                    .|. (to64 v5 `unsafeShiftL` 40)
+                                    .|. (to64 v4 `unsafeShiftL` 32)
+                                    .|. (to64 v3 `unsafeShiftL` 24)
+                                    .|. (to64 v2 `unsafeShiftL` 16)
+                                    .|. (to64 v1 `unsafeShiftL` 8)
+                                    .|. to64 v0)
+                    7 -> do v0 <- peekByteOff ptr 0
+                            v1 <- peekByteOff ptr 1
+                            v2 <- peekByteOff ptr 2
+                            v3 <- peekByteOff ptr 3
+                            v4 <- peekByteOff ptr 4
+                            v5 <- peekByteOff ptr 5
+                            v6 <- peekByteOff ptr 6
+                            return (    lengthBlock
+                                    .|. (to64 v6 `unsafeShiftL` 48)
+                                    .|. (to64 v5 `unsafeShiftL` 40)
+                                    .|. (to64 v4 `unsafeShiftL` 32)
+                                    .|. (to64 v3 `unsafeShiftL` 24)
+                                    .|. (to64 v2 `unsafeShiftL` 16)
+                                    .|. (to64 v1 `unsafeShiftL` 8)
+                                    .|. to64 v0)
+
+        {-# INLINE to64 #-}
+        to64 :: Word8 -> Word64
+        to64 = fromIntegral
+
+        {-# INLINE process #-}
+        process istate m = newState
+            where newState = postInject $! runRoundsCompression $! preInject istate
+                  preInject  (InternalState v0 v1 v2 v3) = InternalState v0 v1 v2 (v3 `xor` m)
+                  postInject (InternalState v0 v1 v2 v3) = InternalState (v0 `xor` m) v1 v2 v3
+
+        {-# INLINE finish #-}
+        finish istate = getDigest $! runRoundsDigest $! preInject istate
+            where getDigest (InternalState v0 v1 v2 v3) = SipHash (v0 `xor` v1 `xor` v2 `xor` v3)
+                  preInject (InternalState v0 v1 v2 v3) = InternalState v0 v1 (v2 `xor` 0xff) v3
+
+        {-# INLINE doRound #-}
+        doRound (InternalState v0 v1 v2 v3) =
+            let !v0'    = v0 + v1
+                !v2'    = v2 + v3
+                !v1'    = v1 `rotateL` 13
+                !v3'    = v3 `rotateL` 16
+                !v1''   = v1' `xor` v0'
+                !v3''   = v3' `xor` v2'
+                !v0''   = v0' `rotateL` 32
+                !v2''   = v2' + v1''
+                !v0'''  = v0'' + v3''
+                !v1'''  = v1'' `rotateL` 17
+                !v3'''  = v3'' `rotateL` 21
+                !v1'''' = v1''' `xor` v2''
+                !v3'''' = v3''' `xor` v0'''
+                !v2'''  = v2'' `rotateL` 32
+             in InternalState v0''' v1'''' v2''' v3''''
+
+        {-# INLINE runRoundsCompression #-}
+        runRoundsCompression st
+          | c == 2    = doRound $! doRound st
+          | otherwise = loopRounds c st
+
+        {-# INLINE runRoundsDigest #-}
+        runRoundsDigest st
+          | d == 4    = doRound $! doRound $! doRound $! doRound st
+          | otherwise = loopRounds d st
+
+        {-# INLINE loopRounds #-}
+        loopRounds 1 !v = doRound v
+        loopRounds n !v = loopRounds (n-1) (doRound v)
+
+        {-# INLINE initSip #-}
+        initSip (SipKey k0 k1) = InternalState (k0 `xor` 0x736f6d6570736575)
+                                               (k1 `xor` 0x646f72616e646f6d)
+                                               (k0 `xor` 0x6c7967656e657261)
+                                               (k1 `xor` 0x7465646279746573)

--- a/src/Crypto/MAC/SipHash.hs
+++ b/src/Crypto/MAC/SipHash.hs
@@ -34,6 +34,7 @@ import Foreign.ForeignPtr
 import Foreign.Ptr
 import Foreign.Storable
 import System.Endian (fromLE64)
+import System.IO.Unsafe (unsafeDupablePerformIO)
 
 -- | SigHash Key
 data SipKey = SipKey {-# UNPACK #-} !Word64 {-# UNPACK #-} !Word64
@@ -50,7 +51,7 @@ hash = hashWith 2 4
 
 -- | same as 'hash', except also specifies the number of sipround iterations for compression and digest.
 hashWith :: Int -> Int -> SipKey -> ByteString -> SipHash
-hashWith c d key (PS ps s fl) = inlinePerformIO $ withForeignPtr ps (\ptr -> runHash (initSip key) (ptr `plusPtr` s) fl)
+hashWith c d key (PS ps s fl) = unsafeDupablePerformIO $ withForeignPtr ps (\ptr -> runHash (initSip key) (ptr `plusPtr` s) fl)
   where runHash !st !ptr l
             | l > 7     = fromLE64 `fmap` peek (castPtr ptr) >>= \v -> runHash (process st v) (ptr `plusPtr` 8) (l-8)
             | otherwise = do


### PR DESCRIPTION
Unfortunately, `siphash` no longer compiles on GHC 9.2 or later, and since `siphash` is deprecated, it is unlikely to receive future updates. For the time being, I have opted to alleviate the situation by internalizing the `siphash` library within `hyperloglog`. Fortunately, the code from `siphash` is relatively self-contained.

Fixes https://github.com/ekmett/hyperloglog/issues/30.