### PR TITLE
Add disclaimers that the code is not cryptographically secure

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -5,6 +5,10 @@ hyperloglog
 
 This package provides a working implementation of HyperLogLog.
 
+**This library should not be used for cryptographic or security applications**,
+as this implementation of HyperLogLog does not generate keys from a
+cryptographically secure source of randomness.
+
 Contact Information
 -------------------
 

--- a/hyperloglog.cabal
+++ b/hyperloglog.cabal
@@ -32,6 +32,10 @@ description:
   .
   Notably it can be used to approximate a set of several billion elements with 1-2% inaccuracy
   in around 1.5k of memory.
+  .
+  __This library should not be used for cryptographic or security
+  applications__, as this implementation of HyperLogLog does not generate keys
+  from a cryptographically secure source of randomness.
 
 extra-source-files:
   .ghci

--- a/src/Data/HyperLogLog.hs
+++ b/src/Data/HyperLogLog.hs
@@ -8,6 +8,10 @@
 --
 -- See the original paper for details:
 -- <http://algo.inria.fr/flajolet/Publications/FlFuGaMe07.pdf>
+--
+-- __This library should not be used for cryptographic or security
+-- applications__, as this implementation of HyperLogLog does not
+-- generate keys from a cryptographically secure source of randomness.
 --------------------------------------------------------------------
 module Data.HyperLogLog
   (

--- a/src/Data/HyperLogLog/Type.hs
+++ b/src/Data/HyperLogLog/Type.hs
@@ -30,6 +30,10 @@
 --
 -- See the original paper for details:
 -- <http://algo.inria.fr/flajolet/Publications/FlFuGaMe07.pdf>
+--
+-- __This library should not be used for cryptographic or security
+-- applications__, as this implementation of HyperLogLog does not
+-- generate keys from a cryptographically secure source of randomness.
 --------------------------------------------------------------------
 module Data.HyperLogLog.Type
   (


### PR DESCRIPTION
This is a first step towards #32 in that it acknowledges that the library in its current state is not cryptographically secure. The task of making the code cryptographically secure (which will almost certainly require backwards-incompatible API changes) is left as future work.