### PR TITLE
Add a `generateHyperLogLog` function

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.19.20240702
+# version: 0.19.20250115
 #
-# REGENDATA ("0.19.20240702",["github","cabal.project"])
+# REGENDATA ("0.19.20250115",["github","cabal.project"])
 #
 name: Haskell-CI
 on:
@@ -83,22 +83,31 @@ jobs:
             compilerVersion: 8.2.2
             setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-8.0.2
-            compilerKind: ghc
-            compilerVersion: 8.0.2
-            setup-method: ghcup
-            allow-failure: false
       fail-fast: false
     steps:
-      - name: apt
+      - name: apt-get install
         run: |
           apt-get update
           apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5 libnuma-dev
+      - name: Install GHCup
+        run: |
           mkdir -p "$HOME/.ghcup/bin"
-          curl -sL https://downloads.haskell.org/ghcup/0.1.20.0/x86_64-linux-ghcup-0.1.20.0 > "$HOME/.ghcup/bin/ghcup"
+          curl -sL https://downloads.haskell.org/ghcup/0.1.30.0/x86_64-linux-ghcup-0.1.30.0 > "$HOME/.ghcup/bin/ghcup"
           chmod a+x "$HOME/.ghcup/bin/ghcup"
-          "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
+      - name: Install cabal-install
+        run: |
           "$HOME/.ghcup/bin/ghcup" install cabal 3.12.1.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
+          echo "CABAL=$HOME/.ghcup/bin/cabal-3.12.1.0 -vnormal+nowrap" >> "$GITHUB_ENV"
+      - name: Install GHC (GHCup)
+        if: matrix.setup-method == 'ghcup'
+        run: |
+          "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
+          HC=$("$HOME/.ghcup/bin/ghcup" whereis ghc "$HCVER")
+          HCPKG=$(echo "$HC" | sed 's#ghc$#ghc-pkg#')
+          HADDOCK=$(echo "$HC" | sed 's#ghc$#haddock#')
+          echo "HC=$HC" >> "$GITHUB_ENV"
+          echo "HCPKG=$HCPKG" >> "$GITHUB_ENV"
+          echo "HADDOCK=$HADDOCK" >> "$GITHUB_ENV"
         env:
           HCKIND: ${{ matrix.compilerKind }}
           HCNAME: ${{ matrix.compiler }}
@@ -109,21 +118,12 @@ jobs:
           echo "LANG=C.UTF-8" >> "$GITHUB_ENV"
           echo "CABAL_DIR=$HOME/.cabal" >> "$GITHUB_ENV"
           echo "CABAL_CONFIG=$HOME/.cabal/config" >> "$GITHUB_ENV"
-          HCDIR=/opt/$HCKIND/$HCVER
-          HC=$("$HOME/.ghcup/bin/ghcup" whereis ghc "$HCVER")
-          HCPKG=$(echo "$HC" | sed 's#ghc$#ghc-pkg#')
-          HADDOCK=$(echo "$HC" | sed 's#ghc$#haddock#')
-          echo "HC=$HC" >> "$GITHUB_ENV"
-          echo "HCPKG=$HCPKG" >> "$GITHUB_ENV"
-          echo "HADDOCK=$HADDOCK" >> "$GITHUB_ENV"
-          echo "CABAL=$HOME/.ghcup/bin/cabal-3.12.1.0 -vnormal+nowrap" >> "$GITHUB_ENV"
           HCNUMVER=$(${HC} --numeric-version|perl -ne '/^(\d+)\.(\d+)\.(\d+)(\.(\d+))?$/; print(10000 * $1 + 100 * $2 + ($3 == 0 ? $5 != 1 : $3))')
           echo "HCNUMVER=$HCNUMVER" >> "$GITHUB_ENV"
           echo "ARG_TESTS=--enable-tests" >> "$GITHUB_ENV"
           echo "ARG_BENCH=--enable-benchmarks" >> "$GITHUB_ENV"
           echo "HEADHACKAGE=false" >> "$GITHUB_ENV"
           echo "ARG_COMPILER=--$HCKIND --with-compiler=$HC" >> "$GITHUB_ENV"
-          echo "GHCJSARITH=0" >> "$GITHUB_ENV"
         env:
           HCKIND: ${{ matrix.compilerKind }}
           HCNAME: ${{ matrix.compiler }}
@@ -206,8 +206,8 @@ jobs:
           touch cabal.project
           touch cabal.project.local
           echo "packages: ${PKGDIR_hyperloglog}" >> cabal.project
-          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "package hyperloglog" >> cabal.project ; fi
-          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods" >> cabal.project ; fi
+          echo "package hyperloglog" >> cabal.project
+          echo "    ghc-options: -Werror=missing-methods" >> cabal.project
           cat >> cabal.project <<EOF
           EOF
           $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: any.$_ installed\n" unless /^(hyperloglog)$/; }' >> cabal.project.local
@@ -242,8 +242,8 @@ jobs:
         run: |
           $CABAL v2-haddock --disable-documentation --haddock-all $ARG_COMPILER --with-haddock $HADDOCK $ARG_TESTS $ARG_BENCH all
       - name: save cache
-        uses: actions/cache/save@v4
         if: always()
+        uses: actions/cache/save@v4
         with:
           key: ${{ runner.os }}-${{ matrix.compiler }}-${{ github.sha }}
           path: ~/.cabal/store

--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -15,6 +15,7 @@
 * Export the `SipKey` data type and define a `reifySipKey` function to promote
   a `SipKey` value to the type level.
 * Define a `type DefaultHyperLogLog = HyperLogLog DefaultSipKey` type synonym.
+* Drop support for GHC 8.0.
 
 0.4.6 [2022.04.18]
 ------------------

--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,3 +1,21 @@
+0.5 [????.??.??]
+----------------
+* Add a `generateHyperLogLog` function that randomly generates a `HyperLogLog`
+  value using system entropy. This function is suitable for scenarios where
+  cryptographic security is a primary consideration.
+* Add an additional `s` type parameter to `HyperLogLog` that encodes the
+  `SipKey` used to configure the hash function when `insert`ing new values.
+  (Previously, inserting a new value would always use a fixed `SipKey`.)
+
+  In order to continue using the old behavior of the `insert` function, one
+  can instantiate `s` to the newly added `DefaultSipKey` type. Note that this
+  is *not* cryptographically secure, however. (In contrast, the
+  `generateHyperLogLog` function instantiates `s` with a randomly generated
+  `SipKey`.)
+* Export the `SipKey` data type and define a `reifySipKey` function to promote
+  a `SipKey` value to the type level.
+* Define a `type DefaultHyperLogLog = HyperLogLog DefaultSipKey` type synonym.
+
 0.4.6 [2022.04.18]
 ------------------
 * Remove the `siphash` dependency. Because `siphash` no longer builds on

--- a/hyperloglog.cabal
+++ b/hyperloglog.cabal
@@ -61,6 +61,7 @@ library
     comonad                   >= 4        && < 6,
     deepseq                   >= 1.3      && < 1.6,
     distributive              >= 0.3      && < 1,
+    entropy                   >= 0.4      && < 0.5,
     ghc-prim,
     hashable                  >= 1.1.2.3  && < 1.6,
     lens                      >= 4        && < 6,

--- a/hyperloglog.cabal
+++ b/hyperloglog.cabal
@@ -11,8 +11,7 @@ homepage:      http://github.com/analytics/hyperloglog
 bug-reports:   http://github.com/analytics/hyperloglog/issues
 copyright:     Copyright (C) 2013-2015 Edward A. Kmett
 build-type:    Simple
-tested-with:   GHC == 8.0.2
-             , GHC == 8.2.2
+tested-with:   GHC == 8.2.2
              , GHC == 8.4.4
              , GHC == 8.6.5
              , GHC == 8.8.4
@@ -52,7 +51,7 @@ flag herbie
 library
   build-depends:
     approximate               >= 0.2.1    && < 1,
-    base                      >= 4.9      && < 5,
+    base                      >= 4.10     && < 5,
     binary                    >= 0.5      && < 0.9,
     bits                      >= 0.2      && < 1,
     bytes                     >= 0.7      && < 1,


### PR DESCRIPTION
Unlike the `HyperLogLog` data constructor or its `mempty` implementation, which allow constructing `HyperLogLog` values using fixed `SipKey`s, `generateHyperLogLog` builds a `HyperLogLog` value using a randomly generated `SipKey` that is derived from system entropy (using the `entropy` library). This prevents an adversary from exploiting the potential for exponentially inaccurate results if a fixed `SipKey` is used, as described in https://eprint.iacr.org/2021/1139.

I have not gone as far as deprecating the parts of the API that allow using fixed `SipKey`s, as there are legitimate use cases for doing so (e.g., data collection across processes). In lieu of this, I have added prominent disclaimers to the relevant Haddocks.

Fixes https://github.com/ekmett/hyperloglog/issues/32.